### PR TITLE
API Link in Footer

### DIFF
--- a/src/apps/api/urls.py
+++ b/src/apps/api/urls.py
@@ -7,7 +7,7 @@ from rest_framework.routers import SimpleRouter
 from api.views.producers import ProducerViewSet
 from .views import competitions, data, profiles, search
 
-
+app_name = 'api'
 API_PREFIX = "v1"
 
 # API routes

--- a/src/apps/api/urls.py
+++ b/src/apps/api/urls.py
@@ -39,7 +39,7 @@ urlpatterns = [
 
     # Docs
     url(r'^swagger(?P<format>\.json|\.yaml)$', schema_view.without_ui(cache_timeout=None), name='schema-json'),
-    url(r'^$', schema_view.with_ui('swagger', cache_timeout=None), name='schema-swagger-ui'),
+    url(r'^$', schema_view.with_ui('swagger', cache_timeout=None), name='docs'),
 
     # Optionally, use "redoc" style
     # url(r'^redoc/$', schema_view.with_ui('redoc', cache_timeout=None), name='schema-redoc'),

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -68,7 +68,7 @@
         </div>
         <div class="item">
             <div class="content">
-                <a href="{% url 'api:schema-swagger-ui' api.API_PREFIX %}" target="_blank">Chahub API</a>
+                <a href="{% url 'api:docs' 'v1' %}" target="_blank">Chahub API</a>
             </div>
         </div>
         <div class="item">

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -68,7 +68,7 @@
         </div>
         <div class="item">
             <div class="content">
-                <a href="{% url 'api:schema-swagger-ui' 1 %}" target="_blank">Chahub API</a>
+                <a href="{% url 'api:schema-swagger-ui' api.API_PREFIX %}" target="_blank">Chahub API</a>
             </div>
         </div>
         <div class="item">

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -68,7 +68,7 @@
         </div>
         <div class="item">
             <div class="content">
-                <a href="{% url 'api:docs' 'v1' %}" target="_blank">Chahub API</a>
+                <a href="{% url 'api:docs' 'v1' %}" target="_blank">API</a>
             </div>
         </div>
         <div class="item">

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -68,6 +68,11 @@
         </div>
         <div class="item">
             <div class="content">
+                <a href="{% url 'api:schema-swagger-ui' 1 %}" target="_blank">Chahub API</a>
+            </div>
+        </div>
+        <div class="item">
+            <div class="content">
                 <a href="https://github.com/codalab/codalab/wiki/Project_About_CodaLab">About</a>
             </div>
         </div>


### PR DESCRIPTION
Resolves #62 and #72 

Creates a link to the Chahub API in the footer.