### PR TITLE
All competitions have a datetime tag

### DIFF
--- a/src/apps/api/views/search.py
+++ b/src/apps/api/views/search.py
@@ -39,7 +39,6 @@ class SearchView(APIView):
             # Setup ES connection, excluding HTML text from our results
             s = get_search_client()
 
-
             # Do search/filtering/sorting
             s = self._search(s, query)
             s = self._filter(s, date_flags, start, end, producer)

--- a/src/apps/competitions/management/commands/update_competition_details.py
+++ b/src/apps/competitions/management/commands/update_competition_details.py
@@ -1,4 +1,4 @@
-from time import sleep
+# from time import sleep
 
 import traceback
 from django.core.management.base import BaseCommand

--- a/src/apps/competitions/management/commands/update_competition_details.py
+++ b/src/apps/competitions/management/commands/update_competition_details.py
@@ -1,5 +1,3 @@
-# from time import sleep
-
 import traceback
 from django.core.management.base import BaseCommand
 from termcolor import colored

--- a/src/apps/factory/management/commands/create_competition.py
+++ b/src/apps/factory/management/commands/create_competition.py
@@ -19,9 +19,9 @@ def _create_fake_user():
     try:
         # Usernames will be in the format <some_username><some_number> IE: shieldshannah53
         temp_email = fake.safe_email()
-        temp_email = "{0}{1}{2}".format(temp_email.split('@')[0] + "@", random.randint(1,9999), temp_email.split('@')[1])
+        temp_email = "{0}{1}{2}".format(temp_email.split('@')[0] + "@", random.randint(1, 9999), temp_email.split('@')[1])
         new_user = CodalabUser.objects.create(
-            username="{0}{1}".format(fake.user_name(), random.randint(1,9999)),
+            username="{0}{1}".format(fake.user_name(), random.randint(1, 9999)),
             name=fake.name(),
             email=temp_email,
         )

--- a/src/static/js/ours/utils.js
+++ b/src/static/js/ours/utils.js
@@ -62,6 +62,31 @@ var pretty_date = function (date_string) {
     }
 }
 
+var deadline_date = function (date_string) {
+    if (!!date_string) {
+        var deadline_count = luxon.DateTime.fromISO(date_string).diffNow(["months", "days", "hours", "minutes", "seconds", "milliseconds"]).toObject()
+        var days_normalized = luxon.Duration.fromObject(deadline_count).shiftTo('days').toObject()
+
+        if (deadline_count.milliseconds < 0) {
+            return 'Phase ended ' + Math.abs(Math.round(days_normalized.days)) + ' days ago'
+        }
+
+        if (deadline_count.months >= 2) {
+            return deadline_count.months + ' months, ' + deadline_count.days + ' days left'
+        } else if (deadline_count.months >= 1) {
+            return deadline_count.days + ' days left'
+        } else if (deadline_count.days >= 7) {
+            return deadline_count.days + ' days, ' + deadline_count.hours + ' hours left'
+        } else if (deadline_count.days >= 1) {
+            return deadline_count.hours + ' hours, ' + deadline_count.minutes + ' minutes left'
+        } else if (deadline_count.hours >= 1) {
+            return deadline_count.minutes + ' minutes left'
+        }
+    } else {
+        return 'No Phase Deadline'
+    }
+};
+
 /* ----------------------------------------------------------------------------
  Dict helpers
  ----------------------------------------------------------------------------*/

--- a/src/static/js/ours/utils.js
+++ b/src/static/js/ours/utils.js
@@ -62,28 +62,38 @@ var pretty_date = function (date_string) {
     }
 }
 
-var deadline_date = function (date_string) {
+var time_difference_from_now = function (date_string) {
     if (!!date_string) {
-        var deadline_count = luxon.DateTime.fromISO(date_string).diffNow(["months", "days", "hours", "minutes", "seconds", "milliseconds"]).toObject()
-        var days_normalized = luxon.Duration.fromObject(deadline_count).shiftTo('days').toObject()
+        return luxon.DateTime.fromISO(date_string).diffNow([
+                "months",
+                "days",
+                "hours",
+                "minutes",
+                "milliseconds"
+            ]
+        ).toObject();
+    }
+}
 
-        if (deadline_count.milliseconds < 0) {
-            return 'Phase ended ' + Math.abs(Math.round(days_normalized.days)) + ' days ago'
+var humanize_time = function (date_string) {
+    if (!!date_string) {
+        var date_diff = time_difference_from_now(date_string)
+        var days_normalized = luxon.Duration.fromObject(date_diff).shiftTo('days').toObject();
+        if (date_diff.milliseconds < 0) {
+            return Math.round(days_normalized.days)
         }
 
-        if (deadline_count.months >= 2) {
-            return deadline_count.months + ' months, ' + deadline_count.days + ' days left'
-        } else if (deadline_count.months >= 1) {
-            return deadline_count.days + ' days left'
-        } else if (deadline_count.days >= 7) {
-            return deadline_count.days + ' days, ' + deadline_count.hours + ' hours left'
-        } else if (deadline_count.days >= 1) {
-            return deadline_count.hours + ' hours, ' + deadline_count.minutes + ' minutes left'
-        } else if (deadline_count.hours >= 1) {
-            return deadline_count.minutes + ' minutes left'
+        if (date_diff.months >= 2) {
+            return date_diff.months + ' months, ' + date_diff.days + ' days left'
+        } else if (date_diff.months >= 1) {
+            return date_diff.days + ' days left'
+        } else if (date_diff.days >= 7) {
+            return date_diff.days + ' days, ' + date_diff.hours + ' hours left'
+        } else if (date_diff.days >= 1) {
+            return date_diff.hours + ' hours, ' + date_diff.minutes + ' minutes left'
+        } else if (date_diff.hours >= 1) {
+            return date_diff.minutes + ' minutes left'
         }
-    } else {
-        return 'No Phase Deadline'
     }
 };
 

--- a/src/static/riot/search.tag
+++ b/src/static/riot/search.tag
@@ -266,19 +266,17 @@
             if (self.refs.start_date.value && self.refs.end_date.value) {
                 var temp_string = self.refs.start_date.value + ' through ' + self.refs.end_date.value
                 $(self.refs.time_filter).dropdown('set text', temp_string)
-            }
-            else if (self.refs.start_date.value) {
+            } else if (self.refs.start_date.value) {
                 var temp_string = 'Starting from ' + self.refs.start_date.value
                 $(self.refs.time_filter).dropdown('set text', temp_string)
-            }
-            else if (self.refs.end_date.value) {
+            } else if (self.refs.end_date.value) {
                 var temp_string = 'End by ' + self.refs.end_date.value
                 $(self.refs.time_filter).dropdown('set text', temp_string)
             }
         }
 
 
-        self.init_values_from_query_params = function() {
+        self.init_values_from_query_params = function () {
             var params = route.query()
 
             // On page load set search bar to search and execute search if we were given a query
@@ -323,6 +321,7 @@
                 console.log("Loading default search results")
                 self.results = DEFAULT_SEARCH_RESULTS
                 self.showing_default_results = true
+                self.prepare_results()
                 self.update()
             } else {
                 // We have some search to perform, not just displaying default results
@@ -337,6 +336,18 @@
             delay(function () {
                 self.search()
             }, 250)
+        }
+
+        self.prepare_results = function () {
+            self.results.forEach(function (comp_result) {
+                var humanized_time = humanize_time(comp_result.current_phase_deadline)
+                comp_result.alert_icon = humanized_time < 0;
+                if (comp_result.alert_icon) {
+                    comp_result.pretty_deadline_time = 'Phase ended ' + Math.abs(humanized_time) + ' days ago'
+                } else {
+                    comp_result.pretty_deadline_time = humanized_time
+                }
+            })
         }
 
         self.clear_search = function () {
@@ -381,12 +392,12 @@
 
             CHAHUB.api.search(filters)
                 .done(function (data) {
-                    self.update({
-                        loading: false,
-                        results: data.results,
-                        suggestions: data.suggestions,
-                        showing_default_results: data.showing_default_results
-                    })
+                    self.loading = false
+                    self.suggestions = data.suggestions
+                    self.showing_default_results = data.showing_default_results
+                    self.results = data.results
+                    self.prepare_results()
+                    self.update()
                 })
         }
 
@@ -427,6 +438,7 @@
         #searchbar
             width 100%
             margin-top 10px
+
             input
                 background-color rgba(255, 255, 255, .95)
                 padding-right 0 !important
@@ -551,6 +563,7 @@
             text-align center
             display flex
             flex-direction column
+
             .icon
                 background-color #C7402D
                 color #e2e2e2
@@ -582,6 +595,7 @@
         #advanced_search_button.active > i.icon
             color #e2e2e2 !important
             background-color #C7402D !important
+
             .icon
                 color #e2e2e2 !important
 
@@ -603,6 +617,7 @@
 
         .ui.button:hover
             color #3f3f3f
+
             .icon
                 opacity 1 !important
 
@@ -676,10 +691,13 @@
             opacity 1 !important
             z-index 1000
             // Buttons on calendar
+
             .icon
                 background-color transparent
                 border none
+
             // Buttons on Date Range Input
+
             .calendar.icon
                 background-color #e2e2e2
                 color #6f6f6f
@@ -747,10 +765,15 @@
                 <span class="participant_label ui right floated mini label tooltip" data-content="Participant count">
                 <i class="user icon"></i> {participant_count}
                 </span>
-                <span style="text-overflow: ellipsis;" class="deadline_label ui right floated red mini label tooltip"
+                <span class="deadline_label ui right floated red mini label tooltip"
                       data-content="Deadline of the current phase"
-                      >
-                <i class="alarm icon"></i> {deadline_date(current_phase_deadline)}
+                      show="{current_phase_deadline}"
+                >
+                <i show="{!alert_icon}" class="alarm icon"></i> {pretty_deadline_time}
+                </span>
+                <span class="deadline_label ui right floated mini green label"
+                      show="{!current_phase_deadline}">
+                Phase Never Ends
                 </span>
                 <span class="prize_label ui right floated mini label tooltip" data-content="Prize Amount"
                       show="{prize}">
@@ -787,6 +810,7 @@
                 color #808080 !important
                 display block
                 font-size .9em !important
+
             p
                 line-height 1.1em !important
 

--- a/src/static/riot/search.tag
+++ b/src/static/riot/search.tag
@@ -746,16 +746,16 @@
                 <div class="mobile_labelwrap"></div>
                 <span class="participant_label ui right floated mini label tooltip" data-content="Participant count">
                 <i class="user icon"></i> {participant_count}
-            </span>
+                </span>
+                <span style="text-overflow: ellipsis;" class="deadline_label ui right floated red mini label tooltip"
+                      data-content="Deadline of the current phase"
+                      >
+                <i class="alarm icon"></i> {deadline_date(current_phase_deadline)}
+                </span>
                 <span class="prize_label ui right floated mini label tooltip" data-content="Prize Amount"
                       show="{prize}">
                 <i class="yellow trophy icon"></i> {prize}
-            </span>
-                <span class="deadline_label ui right floated red mini label tooltip"
-                      data-content="Deadline of the current phase"
-                      show="{current_phase_deadline}">
-                <i class="alarm icon"></i> {pretty_date(current_phase_deadline)}
-            </span>
+                </span>
             </div>
         </div>
     </div>
@@ -837,6 +837,11 @@
             color #dfe3e5 !important
             right 0
             margin 0 2px !important
+            width 45px // May need to be increased to 50px if we expect competitions with more than 10k participants
+            text-align right
+
+            i
+                float left
 
         .prize_label
             background-color rgba(99, 84, 14, 0.68) !important

--- a/src/static/riot/search.tag
+++ b/src/static/riot/search.tag
@@ -763,25 +763,21 @@
             </span>
                 <div class="mobile_labelwrap"></div>
                 <span class="participant_label ui right floated mini label tooltip" data-content="Participant count">
-                <i class="user icon"></i> {participant_count}
+                    <i class="user icon"></i> {participant_count}
                 </span>
-                <span class="deadline_label ui right floated red mini label tooltip"
+                <span class="deadline_label ui right floated mini label tooltip {grey: !!alert_icon, red: !alert_icon}"
                       data-content="Deadline of the current phase"
-                      show="{current_phase_deadline}"
-                >
-                <i show="{!alert_icon}" class="alarm icon"></i> {pretty_deadline_time}
+                      show="{current_phase_deadline}">
+                    <i show="{!alert_icon}" class="alarm icon"></i> {pretty_deadline_time}
                 </span>
-                <span class="deadline_label ui right floated mini green label"
-                      show="{!current_phase_deadline}">
-                Phase Never Ends
+                <span class="deadline_label ui right floated mini green label" show="{!current_phase_deadline}">
+                    Phase Never Ends
                 </span>
-                <span class="prize_label ui right floated mini label tooltip" data-content="Prize Amount"
-                      show="{prize}">
-                <i class="yellow trophy icon"></i> {prize}
+                <span class="prize_label ui right floated mini label tooltip" data-content="Prize Amount" show="{prize}">
+                    <i class="yellow trophy icon"></i> {prize}
                 </span>
             </div>
         </div>
-    </div>
     </div>
 
     <script>
@@ -864,7 +860,7 @@
             width 45px // May need to be increased to 50px if we expect competitions with more than 10k participants
             text-align right
 
-            i
+            .icon
                 float left
 
         .prize_label


### PR DESCRIPTION
Resolves #121 

Shows remaining time on a phase, and if a phase has finished, it shows how long since finished. It also displays No Phase Deadline on competitions which haven't explicitly set a deadline. Logic may be a bit verbose, so if we want to change strictly to days remaining instead of months, hours, and minutes, it will be a simple fix.